### PR TITLE
Stream abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ tokio = { version = "1", optional = true, features = [
     "time",
     "tracing",
 ] }
-tokio-stream = { version = "0.1.11", optional = true }
+tokio-stream = { version = "0.1.14", optional = true }
 tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = [

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -24,9 +24,9 @@ mod unbounded;
 #[cfg(all(feature = "async-std-executor", feature = "channel-tokio"))]
 compile_error!("feature 'async-std-executor' and 'channel-tokio' cannot be used at the same time; 'channel-tokio' needs the tokio runtime");
 
-pub use bounded::{bounded, Receiver, RecvError, SendError, Sender, TryRecvError};
+pub use bounded::{bounded, BoundedStream, Receiver, RecvError, SendError, Sender, TryRecvError};
 pub use oneshot::{oneshot, OneShotReceiver, OneShotRecvError, OneShotSender, OneShotTryRecvError};
 pub use unbounded::{
     unbounded, UnboundedReceiver, UnboundedRecvError, UnboundedSendError, UnboundedSender,
-    UnboundedTryRecvError,
+    UnboundedStream, UnboundedTryRecvError,
 };


### PR DESCRIPTION
Adds a stream wrapper. This should allow us to explicitly use any of the channels as a stream. I'm not super happy about the `T: 'static` restriction, but don't really see a way around it.