### PR TITLE
Default to async-std

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,10 @@ jobs:
     strategy:
       matrix:
         flags:
-          - --cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\" 
+          # no flags set, default to async-std
+          - ""
+          # crates that explicitly choose async-std should keep working
+          - --cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\"
           - --cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"flume\"
           - --cfg async_executor_impl=\"tokio\" --cfg async_channel_impl=\"tokio\"
           - --cfg async_executor_impl=\"tokio\" --cfg async_channel_impl=\"flume\"
@@ -59,7 +62,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
         RUST_LOG: info
-        RUSTFLAGS: "--cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\""
     steps:
       - uses: actions/checkout@v4
       - uses: katyo/publish-crates@v2

--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -10,6 +10,9 @@ jobs:
     strategy:
       matrix:
         flags:
+          # no flags set, default to async-std
+          - ""
+          # crates that explicitly choose async-std should keep working
           - --cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\"
           - --cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"flume\"
           - --cfg async_executor_impl=\"tokio\" --cfg async_channel_impl=\"tokio\"

--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * 1'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:
@@ -21,11 +25,6 @@ jobs:
     timeout-minutes: 60
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: styfle/cancel-workflow-action@0.12.1
-        name: Cancel Outdated Builds
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@v26
@@ -39,12 +38,12 @@ jobs:
 
       - name: Build
         run: |
-          nix develop -c RUSTFLAGS="${{ matrix.flags }}" cargo build --all-targets --workspace --release --features="logging-utils"
+          nix develop -c env RUSTFLAGS="${{ matrix.flags }}" cargo build --all-targets --workspace --release --features="logging-utils"
 
       - name: Test
         run: |
-          nix develop -c RUSTFLAGS="${{ matrix.flags }}" cargo test --all-targets --workspace --release --features="logging-utils"
+          nix develop -c env RUSTFLAGS="${{ matrix.flags }}" cargo test --all-targets --workspace --release --features="logging-utils"
 
       - name: Lint
         run: |
-          nix develop -c RUSTFLAGS="${{ matrix.flags }}" cargo clippy --all-targets --workspace --release --bins --tests --examples --features="logging-utils" -- -D warnings
+          nix develop -c env RUSTFLAGS="${{ matrix.flags }}" cargo clippy --all-targets --workspace --release --bins --tests --examples --features="logging-utils" -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "async-compatibility-layer"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-lock 3.3.0",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-compatibility-layer"
 description = "an abstraction layer for using both async-std and tokio"
 authors = ["Espresso Systems <hello@espressosys.com>"]
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "MIT"
 
@@ -41,7 +41,7 @@ opentelemetry-jaeger = { version = "0.19.0", features = [
 ], optional = true }
 opentelemetry-aws = { version = "0.8.0", features = ["trace"], optional = true }
 
-[target.'cfg(all(async_executor_impl = "tokio"))'.dependencies]
+[target.'cfg(async_executor_impl = "tokio")'.dependencies]
 console-subscriber = { version = "0.2.0" }
 tokio = { version = "1", features = [
     "fs",
@@ -60,13 +60,13 @@ tokio = { version = "1", features = [
 ] }
 tokio-stream = { version = "0.1.14" }
 
-[target.'cfg(all(async_executor_impl = "async-std"))'.dependencies]
+[target.'cfg(not(async_executor_impl = "tokio"))'.dependencies]
 async-std = { version = "1.12", features = [
     "attributes",
     "unstable",
 ]}
 
-[target.'cfg(all(async_channel_impl = "tokio"))'.dependencies]
+[target.'cfg(async_channel_impl = "tokio")'.dependencies]
 tokio = { version = "1", features = [
     "fs",
     "io-util",
@@ -84,7 +84,7 @@ tokio = { version = "1", features = [
 ] }
 tokio-stream = { version = "0.1.14" }
 
-[target.'cfg(all(async_channel_impl = "async-std"))'.dependencies]
+[target.'cfg(not(any(async_channel_impl = "tokio", async_channel_impl = "flume")))'.dependencies]
 async-std = { version = "1.12", features = [
     "attributes",
     "unstable",

--- a/README.md
+++ b/README.md
@@ -2,17 +2,25 @@
 
 This crate exports four things:
 
-- A compatibility/abstraction layer for writing async-executor agnostic code. We support two async executors: async-std and tokio. Each may be toggled with a configuration flag.
-- A compatibility/abstraction layer for writing async channel agnostic code. We support three async channel implementations: async-std-channels. Each may be toggled with a configuration flag.
+- A compatibility/abstraction layer for writing async-executor agnostic code. We
+  support two async executors: async-std and tokio. Each may be toggled with a
+  configuration flag.
+- A compatibility/abstraction layer for writing async channel agnostic code. We
+  support three async channel implementations: async-std, tokio and flume. Each
+  may be toggled with a configuration flag.
 - A library exporting a bunch of useful async primitives.
 - A tracing configuration layer optionally supporting console and opentelemetry integration.
 
 # Example usage
+By default the `async-std` executor and channels are used.
+
+To use tokio:
 
 ```bash
 RUSTFLAGS='--cfg async_executor_impl="tokio" --cfg async_channel_impl="tokio"' cargo build
 ```
 
-`async_executor_impl` may be either `tokio` or `async-std`. `async_channel_impl` may be either `tokio`, `async-std`, or `flume`. Note that using `tokio` channels requires `tokio` to be the runtime. Note that the async executor impl and async channel impl must be set in order for this crate to compile successfully.
+`async_executor_impl` may be either `tokio` or `async-std`. `async_channel_impl`
+may be either `tokio`, `async-std`, or `flume`.
 
-
+Note that using `tokio` channels requires `tokio` to be the runtime.

--- a/flake.lock
+++ b/flake.lock
@@ -1,49 +1,64 @@
 {
   "nodes": {
-    "fenix": {
+    "flake-utils": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1711779695,
-        "narHash": "sha256-iGb6ptUaNBOCftKnNJiWT5z1ftngfNtwqJkD8Z9Vwfw=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "aaeaf4574767a0f5ed1787e990139aefcf4db103",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711715736,
-        "narHash": "sha256-9slQ609YqT9bT/MNX9+5k5jltL9zgpn36DpFB7TkttM=",
+        "lastModified": 1714253743,
+        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "807c549feabce7eddbf259dbdcec9e0600a0660d",
+        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1706487304,
+        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
         "type": "github"
       },
       "original": {
@@ -55,26 +70,27 @@
     },
     "root": {
       "inputs": {
-        "fenix": "fenix",
-        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "utils": "utils"
+        "rust-overlay": "rust-overlay"
       }
     },
-    "rust-analyzer-src": {
-      "flake": false,
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
       "locked": {
-        "lastModified": 1711731711,
-        "narHash": "sha256-dyezzeSbWMpflma+E9USmvSxuLgGcNGcGw3cOnX36ko=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "f5a9250147f6569d8d89334dc9cca79c0322729f",
+        "lastModified": 1714616033,
+        "narHash": "sha256-JcWAjIDl3h0bE/pII0emeHwokTeBl+SWrzwrjoRu7a0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3e416d5067ba31ff8ac31eeb763e4388bdf45089",
         "type": "github"
       },
       "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     },
@@ -93,21 +109,18 @@
         "type": "github"
       }
     },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
+    "systems_2": {
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,66 +1,27 @@
 {
-  description = "Nll crate";
+  description = "A devShell example";
 
-  nixConfig = {
-    extra-substituters = [ "https://espresso-systems-private.cachix.org" ];
-    extra-trusted-public-keys = [
-      "espresso-systems-private.cachix.org-1:LHYk03zKQCeZ4dvg3NctyCq88e44oBZVug5LpYKjPRI="
-    ];
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    utils.url = "github:numtide/flake-utils";
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
-    fenix = {
-      url = "github:nix-community/fenix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-  };
-
-  outputs =
-    { self, nixpkgs, flake-compat, utils, fenix }:
-    utils.lib.eachDefaultSystem (system:
+  outputs = { nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
       let
-        fenixStable = fenix.packages.${system}.stable.withComponents [
-          "cargo"
-          "clippy"
-          "rust-src"
-          "rustc"
-          "rustfmt"
-          "llvm-tools-preview"
-        ];
-
-        CARGO_TARGET_DIR = "target_dirs/nix_rustc";
-
-        rustOverlay = final: prev: {
-          rustc = fenixStable;
-          cargo = fenixStable;
-          rust-src = fenixStable;
-        };
-
+        overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ rustOverlay ];
+          inherit system overlays;
         };
-
-        buildDeps = with pkgs;
-          [
-            nixpkgs-fmt
-            fenix.packages.${system}.rust-analyzer
-          ] ++ lib.optionals stdenv.isDarwin [
-            darwin.apple_sdk.frameworks.Security
-            pkgs.libiconv
-            darwin.apple_sdk.frameworks.SystemConfiguration
+      in
+      with pkgs;
+      {
+        CARGO_TARGET_DIR = "target_dirs/nix_rustc";
+        devShells.default = mkShell {
+          buildInputs = [
+            just
+            rust-bin.stable.latest.default
           ];
-      in {
-        devShell = pkgs.mkShell {
-          inherit CARGO_TARGET_DIR;
-          buildInputs = [ fenixStable ] ++ buildDeps;
         };
-
-      });
+      }
+    );
 }

--- a/justfile
+++ b/justfile
@@ -1,0 +1,27 @@
+async_std := '--cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\"'
+tokio := '--cfg async_executor_impl=\"tokio\" --cfg async_channel_impl=\"tokio\"'
+async_std_flume := '--cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"flume\"'
+tokio_flume := '--cfg async_executor_impl=\"tokio\" --cfg async_channel_impl=\"flume\"'
+
+
+matrix *args:
+    {{args}}
+    env RUSTFLAGS="{{async_std}}" RUSTDOCFLAGS="{{async_std}}" {{args}}
+    env RUSTFLAGS="{{tokio}}" RUSTDOCFLAGS="{{tokio}}" {{args}}
+    env RUSTFLAGS="{{async_std_flume}}" RUSTDOCFLAGS="{{async_std_flume}}" {{args}}
+    env RUSTFLAGS="{{tokio_flume}}" RUSTDOCFLAGS="{{tokio_flume}}" {{args}}
+
+test *args:
+    cargo test {{args}}
+
+test-all *args:
+    just matrix just test {{args}}
+
+test-all-logging-utils *args:
+    just test-all --features logging-utils {{args}}
+
+clippy:
+    cargo clippy --all-targets --workspace --release --bins --tests --examples --features="logging-utils" -- -D warnings
+
+clippy-all *args:
+    just matrix just clippy

--- a/src/async_primitives/subscribable_mutex.rs
+++ b/src/async_primitives/subscribable_mutex.rs
@@ -5,12 +5,10 @@ use futures::{stream::FuturesOrdered, Future, FutureExt};
 use std::{fmt, time::Duration};
 use tracing::warn;
 
-#[cfg(async_executor_impl = "async-std")]
+#[cfg(not(async_executor_impl = "tokio"))]
 use async_std::prelude::StreamExt;
 #[cfg(async_executor_impl = "tokio")]
 use tokio_stream::StreamExt;
-#[cfg(not(any(async_executor_impl = "async-std", async_executor_impl = "tokio")))]
-std::compile_error! {"The cfg flag async_executor_impl must be set in rustflags to either \"async-std\" or \"tokio\" for this crate. Try adding `--cfg async_executor_impl=\"tokio\""}
 
 /// A mutex that can register subscribers to be notified. This works in the same way as [`Mutex`], but has some additional functions:
 ///
@@ -254,7 +252,7 @@ mod tests {
         async_executor_impl = "tokio",
         tokio::test(flavor = "multi_thread", worker_threads = 2)
     )]
-    #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+    #[cfg_attr(not(async_executor_impl = "tokio"), async_std::test)]
     async fn test_wait_timeout_until() {
         let mutex: Arc<SubscribableMutex<usize>> = Arc::default();
         {
@@ -279,7 +277,7 @@ mod tests {
         async_executor_impl = "tokio",
         tokio::test(flavor = "multi_thread", worker_threads = 2)
     )]
-    #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+    #[cfg_attr(not(async_executor_impl = "tokio"), async_std::test)]
     async fn test_wait_timeout_until_fail() {
         let mutex: Arc<SubscribableMutex<usize>> = Arc::default();
         {
@@ -303,7 +301,7 @@ mod tests {
         async_executor_impl = "tokio",
         tokio::test(flavor = "multi_thread", worker_threads = 2)
     )]
-    #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+    #[cfg_attr(not(async_executor_impl = "tokio"), async_std::test)]
     async fn test_compare_and_set() {
         let mutex = SubscribableMutex::new(5usize);
         let subscriber = mutex.subscribe().await;
@@ -325,7 +323,7 @@ mod tests {
         async_executor_impl = "tokio",
         tokio::test(flavor = "multi_thread", worker_threads = 2)
     )]
-    #[cfg_attr(async_executor_impl = "async-std", async_std::test)]
+    #[cfg_attr(not(async_executor_impl = "tokio"), async_std::test)]
     async fn test_subscriber() {
         let mutex = SubscribableMutex::new(5usize);
         let subscriber = mutex.subscribe().await;

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -21,8 +21,10 @@ mod oneshot;
 /// Unbounded channels
 mod unbounded;
 
-#[cfg(all(async_executor_impl = "async-std", async_channel_impl = "tokio"))]
-compile_error!("async_executor_impl = 'async-std-executor' and async_channel_impl = 'channel-tokio' cannot be used together; 'channel-tokio' needs the tokio runtime");
+#[cfg(all(not(async_executor_impl = "tokio"), async_channel_impl = "tokio"))]
+compile_error!(
+    "async_channel_impl = 'tokio' requires tokio runtime, e. g. async_executor_impl = 'tokio'"
+);
 
 pub use bounded::{bounded, BoundedStream, Receiver, RecvError, SendError, Sender, TryRecvError};
 pub use oneshot::{oneshot, OneShotReceiver, OneShotRecvError, OneShotSender, OneShotTryRecvError};

--- a/src/channel/bounded.rs
+++ b/src/channel/bounded.rs
@@ -75,7 +75,7 @@ mod inner {
 }
 
 /// inner module, used to group feature-specific imports
-#[cfg(async_channel_impl = "async-std")]
+#[cfg(not(any(async_channel_impl = "flume", async_channel_impl = "tokio")))]
 mod inner {
     pub use async_std::channel::{RecvError, SendError, TryRecvError};
 
@@ -134,7 +134,7 @@ impl<T> Receiver<T> {
         let result = self.0.recv_async().await;
         #[cfg(async_channel_impl = "tokio")]
         let result = self.0.recv().await.ok_or(RecvError);
-        #[cfg(async_channel_impl = "async-std")]
+        #[cfg(not(any(async_channel_impl = "flume", async_channel_impl = "tokio")))]
         let result = self.0.recv().await;
 
         result
@@ -144,7 +144,7 @@ impl<T> Receiver<T> {
     where
         T: 'static,
     {
-        #[cfg(async_channel_impl = "async-std")]
+        #[cfg(not(any(async_channel_impl = "flume", async_channel_impl = "tokio")))]
         let result = self.0;
         #[cfg(async_channel_impl = "tokio")]
         let result = tokio_stream::wrappers::ReceiverStream::new(self.0);
@@ -226,7 +226,7 @@ impl<T> Stream for BoundedStream<T> {
             Pin::new(&mut self.0),
             cx,
         );
-        #[cfg(async_channel_impl = "async-std")]
+        #[cfg(not(any(async_channel_impl = "flume", async_channel_impl = "tokio")))]
         return <async_std::channel::Receiver<T> as Stream>::poll_next(Pin::new(&mut self.0), cx);
     }
 }

--- a/src/channel/unbounded.rs
+++ b/src/channel/unbounded.rs
@@ -92,7 +92,7 @@ mod inner {
 }
 
 /// inner module, used to group feature-specific imports
-#[cfg(async_channel_impl = "async-std")]
+#[cfg(not(any(async_channel_impl = "flume", async_channel_impl = "tokio")))]
 mod inner {
     use async_std::channel::{Receiver, Sender};
     pub use async_std::channel::{
@@ -141,7 +141,7 @@ impl<T> UnboundedSender<T> {
         let result = self.0.send_async(msg).await;
         #[cfg(async_channel_impl = "tokio")]
         let result = self.0.send(msg);
-        #[cfg(async_channel_impl = "async-std")]
+        #[cfg(not(any(async_channel_impl = "flume", async_channel_impl = "tokio")))]
         let result = self.0.send(msg).await;
         result
     }
@@ -160,13 +160,13 @@ impl<T> UnboundedReceiver<T> {
         let result = self.0.recv_async().await;
         #[cfg(async_channel_impl = "tokio")]
         let result = self.0.lock().await.recv().await.ok_or(UnboundedRecvError);
-        #[cfg(async_channel_impl = "async-std")]
+        #[cfg(not(any(async_channel_impl = "flume", async_channel_impl = "tokio")))]
         let result = self.0.recv().await;
         result
     }
     /// Turn this receiver into a stream.
     pub fn into_stream(self) -> UnboundedStream<T> {
-        #[cfg(async_channel_impl = "async-std")]
+        #[cfg(not(any(async_channel_impl = "flume", async_channel_impl = "tokio")))]
         let result = self.0;
         #[cfg(async_channel_impl = "tokio")]
         let result = tokio_stream::wrappers::UnboundedReceiverStream::new(self.0.into_inner());
@@ -270,7 +270,7 @@ impl<T> Stream for UnboundedStream<T> {
             Pin::new(&mut self.0),
             cx,
         );
-        #[cfg(async_channel_impl = "async-std")]
+        #[cfg(not(any(async_channel_impl = "flume", async_channel_impl = "tokio")))]
         return <async_std::channel::Receiver<T> as Stream>::poll_next(Pin::new(&mut self.0), cx);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,8 @@ std::compile_error!(
     "Both cfg options \"async-std\" and \"tokio\" must not be concurrently enabled for this crate."
 );
 
-#[cfg(not(any(async_executor_impl = "async-std", async_executor_impl = "tokio")))]
-compile_error! {"Either config option \"async-std\" or \"tokio\" must be enabled for this crate."}
-
 /// abstraction over both `tokio` and `async-std`, making it possible to use either based on a feature flag
-#[cfg(async_executor_impl = "async-std")]
+#[cfg(not(async_executor_impl = "tokio"))]
 #[path = "art/async-std.rs"]
 pub mod art;
 


### PR DESCRIPTION
There's no issue, based on discussion on [zulip](https://espresso.zulipchat.com/#narrow/stream/330967-Sequencer/topic/Sequencer.20crate.20RUSTFLAGS.20requirement.20.26.20building.20with.20tokio) it should not be required for consumers of this crate to always set RUSTFLAGS.

Instead of checking for presence of async-std, tokio or flume specified with `--cfg` the crate now checks for presence of tokio or flume and defaults to async-std if neither of those are set.

### This PR:
- Change cfg directives to use async-std channels and executor if
  nothing is specified via rust flags.
- Add new empty RUSTFLAGS matrix variant to CI jobs.
- Add a justfile for local testing.
- Update README.
- Fix and simplify flake.nix.

### This PR does not:
- Fix all the outdated comments, for example about cargo features.

### Key places to review:
The cfg directives.

### How to test this PR: 
For example with `just test-all` or the other added just recipes.

### Things tested
Manually tested that setting setting channels to tokio without using the tokio executor still fails. E. .g. `env RUSTFLAGS="--cfg async_channel_impl=\"tokio\"" cargo check `
